### PR TITLE
Fix wrong time representation in SinceLeaderboard

### DIFF
--- a/src/main/java/de/c0debase/bot/pagination/paginations/SinceLeaderboard.java
+++ b/src/main/java/de/c0debase/bot/pagination/paginations/SinceLeaderboard.java
@@ -85,7 +85,7 @@ public class SinceLeaderboard extends Pagination {
             int count = entry.getKey();
             if (member != null) {
                 long days = ChronoUnit.DAYS.between(member.getTimeJoined(), LocalDateTime.now().atOffset(ZoneOffset.UTC));
-                embedBuilder.appendDescription("`" + count + ")` " + StringUtils.replaceCharacter(member.getEffectiveName()) + "#" + member.getUser().getDiscriminator() + " (Beitritt am " + member.getTimeJoined().toInstant().atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("dd.MM.yyyy hh:mm")) + " / Seit " + days + " Tag" + (days == 1 ? "" : "en") + ")\n");
+                embedBuilder.appendDescription("`" + count + ")` " + StringUtils.replaceCharacter(member.getEffectiveName()) + "#" + member.getUser().getDiscriminator() + " (Beitritt am " + member.getTimeJoined().toInstant().atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm")) + " / Seit " + days + " Tag" + (days == 1 ? "" : "en") + ")\n");
             } else {
                 embedBuilder.appendDescription("`" + count + ")` undefined#0000\n");
             }


### PR DESCRIPTION
Use 0-23 time format instead of 1-12 (AM/PM).

![Discord_Screenshot](https://user-images.githubusercontent.com/31598087/80262499-e47b0680-868d-11ea-8df4-14ee87ee2068.png)
